### PR TITLE
[어드민] 댓글 관리 페이지 기능 테스트 정의

### DIFF
--- a/src/main/java/com/springstudy/projectboardadmin/dto/ArticleCommentDto.java
+++ b/src/main/java/com/springstudy/projectboardadmin/dto/ArticleCommentDto.java
@@ -1,0 +1,20 @@
+package com.springstudy.projectboardadmin.dto;
+
+import java.time.LocalDateTime;
+
+public record ArticleCommentDto(
+        Long id,
+        Long articleId,
+        UserAccountDto userAccount,
+        Long parentCommentId,
+        String content,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccount, Long parentCommentId, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleCommentDto(id, articleId, userAccount, parentCommentId, content, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+}

--- a/src/main/java/com/springstudy/projectboardadmin/dto/response/ArticleClientResponse.java
+++ b/src/main/java/com/springstudy/projectboardadmin/dto/response/ArticleClientResponse.java
@@ -2,9 +2,7 @@ package com.springstudy.projectboardadmin.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.springstudy.projectboardadmin.dto.ArticleDto;
-import org.springframework.data.domain.Page;
 
-import javax.persistence.Embedded;
 import java.util.List;
 
 public record ArticleClientResponse(

--- a/src/main/java/com/springstudy/projectboardadmin/dto/response/ArticleCommentClientResponse.java
+++ b/src/main/java/com/springstudy/projectboardadmin/dto/response/ArticleCommentClientResponse.java
@@ -1,0 +1,37 @@
+package com.springstudy.projectboardadmin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.springstudy.projectboardadmin.dto.ArticleCommentDto;
+
+import java.util.List;
+
+public record ArticleCommentClientResponse(
+        @JsonProperty("_embedded") Embedded embedded,
+        @JsonProperty("page") Page page
+) {
+
+    public static ArticleCommentClientResponse empty() {
+        return new ArticleCommentClientResponse(
+                new Embedded(List.of()),
+                new Page(1, 0, 1, 0)
+        );
+    }
+
+    public static ArticleCommentClientResponse of(List<ArticleCommentDto> articleComments) {
+        return new ArticleCommentClientResponse(
+                new Embedded(articleComments),
+                new Page(articleComments.size(), articleComments.size(), 1, 0)
+        );
+    }
+
+    public List<ArticleCommentDto> articleComments() { return this.embedded().articleComments(); }
+
+    public record Embedded(List<ArticleCommentDto> articleComments) {}
+
+    public record Page(
+            int size,
+            long totalElements,
+            int totalPages,
+            int number
+    ) {}
+}

--- a/src/main/java/com/springstudy/projectboardadmin/service/ArticleCommentManagementService.java
+++ b/src/main/java/com/springstudy/projectboardadmin/service/ArticleCommentManagementService.java
@@ -1,0 +1,24 @@
+package com.springstudy.projectboardadmin.service;
+
+import com.springstudy.projectboardadmin.dto.ArticleCommentDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleCommentManagementService {
+
+    public List<ArticleCommentDto> getArticleComments() {
+        return List.of();
+    }
+
+    public ArticleCommentDto getArticleComment(Long articleCommentId) {
+        return null;
+    }
+
+    public void deleteArticleComment(Long articleCommentId) {
+
+    }
+}

--- a/src/test/java/com/springstudy/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/springstudy/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,23 +1,37 @@
 package com.springstudy.projectboardadmin.controller;
 
 import com.springstudy.projectboardadmin.config.SecurityConfig;
+import com.springstudy.projectboardadmin.domain.constant.RoleType;
+import com.springstudy.projectboardadmin.dto.ArticleCommentDto;
+import com.springstudy.projectboardadmin.dto.UserAccountDto;
+import com.springstudy.projectboardadmin.service.ArticleCommentManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("View 컨트롤러 - 댓글 관리")
+@DisplayName("컨트롤러 - 댓글 관리")
 @Import(SecurityConfig.class)
 @WebMvcTest(ArticleCommentManagementController.class)
 class ArticleCommentManagementControllerTest {
 
     private final MockMvc mvc;
+
+    @MockBean private ArticleCommentManagementService articleCommentManagementService;
 
     public ArticleCommentManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
@@ -27,15 +41,82 @@ class ArticleCommentManagementControllerTest {
     @Test
     void givenNothing_whenRequestingArticleCommentManagementView_thenReturnsArticleCommentManagementView() throws Exception {
         // Given
+        given(articleCommentManagementService.getArticleComments()).willReturn(List.of());
 
         // When
         mvc.perform(get("/management/article-comments"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/article-comments"));
-
+                .andExpect(view().name("management/article-comments"))
+                .andExpect(model().attribute("comments", List.of()));
+        then(articleCommentManagementService).should().getArticleComments();
         // Then
 
+    }
+
+    @DisplayName("[data][GET] 댓글 1개 - 정상 호출")
+    @Test
+    void givenCommentId_whenRequestingArticleComment_thenReturnsArticleComment() throws Exception {
+        // Given
+        Long articleCommentId = 1L;
+        ArticleCommentDto articleCommentDto = createArticleCommentDto("comment");
+        given(articleCommentManagementService.getArticleComment(articleCommentId)).willReturn(articleCommentDto);
+
+        // When
+        mvc.perform(get("/management/article-comments" + articleCommentId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(articleCommentId))
+                .andExpect(jsonPath("$.content").value(articleCommentDto.content()))
+                .andExpect(jsonPath("$.userAccount.nickname").value(articleCommentDto.userAccount().nickname()));
+        then(articleCommentManagementService).should().getArticleComment(articleCommentId);
+        // Then
+
+    }
+
+    @DisplayName("[view][POST] 댓글 삭제 - 정상 호출")
+    @Test
+    void givenCommentId_whenRequestingDeletion_thenRedirectsToArticleCommentManagementView() throws Exception {
+        // Given
+        Long articleCommentId = 1L;
+        willDoNothing().given(articleCommentManagementService).deleteArticleComment(articleCommentId);
+
+        // When
+        mvc.perform(
+                        post("/management/article-comments/" + articleCommentId)
+                                .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/management/article-comments"))
+                .andExpect(redirectedUrl("/management/article-comments"));
+        then(articleCommentManagementService).should().deleteArticleComment(articleCommentId);
+        // Then
+
+    }
+
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
+                1L,
+                1L,
+                createUserAccountDto(),
+                null,
+                content,
+                LocalDateTime.now(),
+                "Ihj",
+                LocalDateTime.now(),
+                "Ihj"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "ihjTest",
+                "pw",
+                Set.of(RoleType.ADMIN),
+                "ihj@email.com",
+                "Ihj",
+                "memo"
+        );
     }
 
 }

--- a/src/test/java/com/springstudy/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/springstudy/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -77,7 +77,7 @@ class ArticleManagementControllerTest {
 
     }
 
-    @DisplayName("[data][POST] 게시글 삭제 - 정상 호출")
+    @DisplayName("[view][POST] 게시글 삭제 - 정상 호출")
     @Test
     void givenArticleId_whenRequestingDeletion_thenRedirectsToArticleManagementView() throws Exception {
         // Given

--- a/src/test/java/com/springstudy/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/springstudy/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("View 컨트롤러 - 게시글 관리")
+@DisplayName("컨트롤러 - 게시글 관리")
 @Import(SecurityConfig.class)
 @WebMvcTest(ArticleManagementController.class)
 class ArticleManagementControllerTest {
@@ -77,7 +77,7 @@ class ArticleManagementControllerTest {
 
     }
 
-    @DisplayName("[data][GET] 게시글 삭제 - 정상 호출")
+    @DisplayName("[data][POST] 게시글 삭제 - 정상 호출")
     @Test
     void givenArticleId_whenRequestingDeletion_thenRedirectsToArticleManagementView() throws Exception {
         // Given

--- a/src/test/java/com/springstudy/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/springstudy/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -2,11 +2,10 @@ package com.springstudy.projectboardadmin.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.springstudy.projectboardadmin.domain.constant.RoleType;
-import com.springstudy.projectboardadmin.dto.ArticleDto;
+import com.springstudy.projectboardadmin.dto.ArticleCommentDto;
 import com.springstudy.projectboardadmin.dto.UserAccountDto;
 import com.springstudy.projectboardadmin.dto.properties.ProjectProperties;
-import com.springstudy.projectboardadmin.dto.response.ArticleClientResponse;
-import org.junit.jupiter.api.Disabled;
+import com.springstudy.projectboardadmin.dto.response.ArticleCommentClientResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,8 +29,8 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 @ActiveProfiles("test")
-@DisplayName("비즈니스 로직 - 게시글 관리")
-class ArticleManagementServiceTest {
+@DisplayName("비즈니스 로직 - 댓글 관리")
+class ArticleCommentManagementServiceTest {
 
 //    @Disabled("실제 API 호출 결과 관찰용이므로 평상시엔 비활성화")
     @DisplayName("실제 API 호출 테스트")
@@ -39,49 +38,42 @@ class ArticleManagementServiceTest {
     @Nested
     class RealApiTest {
 
-        private final ArticleManagementService sut;
+        private final ArticleCommentManagementService sut;
 
         @Autowired
-        public RealApiTest(ArticleManagementService sut) {
+        public RealApiTest(ArticleCommentManagementService sut) {
             this.sut = sut;
         }
 
-        @DisplayName("게시글 API를 호출하면, 게시글을 가져온다.")
+        @DisplayName("댓글 API를 호출하면, 댓글을 가져온다.")
         @Test
-        void givenNothing_whenCallingArticleApi_thenReturnsArticleList() {
+        void givenNothing_whenCallingCommentApi_thenReturnsCommentList() {
             // Given
 
             // When
-            List<ArticleDto> result = sut.getArticles();
+            List<ArticleCommentDto> result = sut.getArticleComments();
 
             // Then
             System.out.println(result.stream().findFirst());
             assertThat(result).isNotNull();
         }
-
     }
 
 
     @DisplayName("API mocking 테스트")
     @EnableConfigurationProperties(ProjectProperties.class)
     @AutoConfigureWebClient(registerRestTemplate = true)
-    @RestClientTest(ArticleManagementService.class)
+    @RestClientTest(ArticleCommentManagementService.class)
     @Nested
     class RestTemplateTest {
 
-        private final ArticleManagementService sut;
-
+        private final ArticleCommentManagementService sut;
         private final ProjectProperties projectProperties;
         private final MockRestServiceServer server;
         private final ObjectMapper mapper;
 
         @Autowired
-        public RestTemplateTest(
-                ArticleManagementService sut,
-                ProjectProperties projectProperties,
-                MockRestServiceServer server,
-                ObjectMapper mapper
-        ) {
+        public RestTemplateTest(ArticleCommentManagementService sut, ProjectProperties projectProperties, MockRestServiceServer server, ObjectMapper mapper) {
             this.sut = sut;
             this.projectProperties = projectProperties;
             this.server = server;
@@ -89,80 +81,78 @@ class ArticleManagementServiceTest {
         }
 
 
-        @DisplayName("게시글 목록 API를 호출하면, 게시글들을 가져온다.")
+        @DisplayName("댓글 목록 API를 호출하면, 댓글들을 가져온다.")
         @Test
-        void givenNothing_whenCallingArticlesApi_thenReturnsArticleList() throws Exception {
+        void givenNothing_whenCallingCommentApi_thenReturnsCommentList() throws Exception {
             // Given
-            ArticleDto expectedArticle = createArticleDto("title", "content");
-            ArticleClientResponse expectedResponse = ArticleClientResponse.of(List.of(expectedArticle));
+            ArticleCommentDto expectedComment = createArticleCommentDto("댓글");
+            ArticleCommentClientResponse expectedResponse = ArticleCommentClientResponse.of(List.of(expectedComment));
             server
-                    .expect(requestTo(projectProperties.board().url() + "/api/articles?size=10000"))
+                    .expect(requestTo(projectProperties.board().url() + "/api/articleComments?size=10000"))
                     .andRespond(withSuccess(
                             mapper.writeValueAsString(expectedResponse),
                             MediaType.APPLICATION_JSON
                     ));
 
             // When
-            List<ArticleDto> result = sut.getArticles();
+            List<ArticleCommentDto> result = sut.getArticleComments();
 
             // Then
             assertThat(result).first()
-                    .hasFieldOrPropertyWithValue("id", expectedArticle.id())
-                    .hasFieldOrPropertyWithValue("title", expectedArticle.title())
-                    .hasFieldOrPropertyWithValue("content", expectedArticle.content())
-                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccount().nickname());
+                    .hasFieldOrPropertyWithValue("id", expectedComment.id())
+                    .hasFieldOrPropertyWithValue("content", expectedComment.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccount().nickname());
             server.verify();
         }
 
-        @DisplayName("게시글 ID와 함께 게시글 API를 호출하면, 게시글을 가져온다.")
+        @DisplayName("댓글 ID와 함께 댓글 API를 호출하면, 댓글을 가져온다.")
         @Test
-        void givenNothing_whenCallingArticleApi_thenReturnsArticle() throws Exception {
+        void givenCommentId_whenCallingCommentApi_thenReturnsComment() throws Exception {
             // Given
-            Long articleId = 1L;
-            ArticleDto expectedArticle = createArticleDto("title", "content");
+            Long articleCommentId = 1L;
+            ArticleCommentDto expectedComment = createArticleCommentDto("댓글");
             server
-                    .expect(requestTo(projectProperties.board().url() + "/api/articles" + articleId))
+                    .expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleCommentId))
                     .andRespond(withSuccess(
-                            mapper.writeValueAsString(expectedArticle),
+                            mapper.writeValueAsString(expectedComment),
                             MediaType.APPLICATION_JSON
                     ));
 
             // When
-            ArticleDto result = sut.getArticle(articleId);
+            ArticleCommentDto result = sut.getArticleComment(articleCommentId);
 
             // Then
             assertThat(result)
-                    .hasFieldOrPropertyWithValue("id", expectedArticle.id())
-                    .hasFieldOrPropertyWithValue("title", expectedArticle.title())
-                    .hasFieldOrPropertyWithValue("content", expectedArticle.content())
-                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccount().nickname());
+                    .hasFieldOrPropertyWithValue("id", expectedComment.id())
+                    .hasFieldOrPropertyWithValue("content", expectedComment.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccount().nickname());
             server.verify();
         }
 
-        @DisplayName("게시글 ID와 함께 게시글 삭제 API를 호출하면, 게시글을 삭제한다.")
+        @DisplayName("댓글 ID와 함께 댓글 삭제 API를 호출하면, 댓글을 삭제한다.")
         @Test
-        void givenArticleId_whenCallingDeleteArticleApi_thenDeletesArticle() throws Exception {
+        void givenCommentId_whenCallingDeleteCommentApi_thenDeletesComment() throws Exception {
             // Given
-            Long articleId = 1L;
+            Long articleCommentId = 1L;
             server
-                    .expect(requestTo(projectProperties.board().url() + "/api/articles" + articleId))
+                    .expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleCommentId))
                     .andExpect(method(HttpMethod.DELETE))
                     .andRespond(withSuccess());
 
             // When
-            sut.deleteArticle(articleId);
+            sut.deleteArticleComment(articleCommentId);
 
             // Then
             server.verify();
         }
 
-        private ArticleDto createArticleDto(String title, String content) {
-            return ArticleDto.of(
+        private ArticleCommentDto createArticleCommentDto(String content) {
+            return ArticleCommentDto.of(
+                    1L,
                     1L,
                     createUserAccountDto(),
-                    title,
-                    content,
                     null,
+                    content,
                     LocalDateTime.now(),
                     "Ihj",
                     LocalDateTime.now(),
@@ -180,6 +170,6 @@ class ArticleManagementServiceTest {
                     "memo"
             );
         }
-
     }
+
 }

--- a/src/test/java/com/springstudy/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/springstudy/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -110,11 +110,11 @@ class ArticleManagementServiceTest {
                     .hasFieldOrPropertyWithValue("id", expectedArticle.id())
                     .hasFieldOrPropertyWithValue("title", expectedArticle.title())
                     .hasFieldOrPropertyWithValue("content", expectedArticle.content())
-                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccountDto().nickname());
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccount().nickname());
             server.verify();
         }
 
-        @DisplayName("게시글 API를 호출하면, 게시글을 가져온다.")
+        @DisplayName("게시글 ID와 함께 게시글 API를 호출하면, 게시글을 가져온다.")
         @Test
         void givenNothing_whenCallingArticleApi_thenReturnsArticle() throws Exception {
             // Given
@@ -135,13 +135,13 @@ class ArticleManagementServiceTest {
                     .hasFieldOrPropertyWithValue("id", expectedArticle.id())
                     .hasFieldOrPropertyWithValue("title", expectedArticle.title())
                     .hasFieldOrPropertyWithValue("content", expectedArticle.content())
-                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccountDto().nickname());
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccount().nickname());
             server.verify();
         }
 
         @DisplayName("게시글 ID와 함께 게시글 삭제 API를 호출하면, 게시글을 삭제한다.")
         @Test
-        void givenArticleId_whenCallingDeleteArticleApi_thenDeletesAnArticle() throws Exception {
+        void givenArticleId_whenCallingDeleteArticleApi_thenDeletesArticle() throws Exception {
             // Given
             Long articleId = 1L;
             server


### PR DESCRIPTION
이 pr은 댓글 관리 페이지 기능을 구현하기 위한 비즈니스 로직과 컨트롤러 테스트를 추가한다.
구현이 없으므로 테스트가 실패하는 상태.

This closes #26